### PR TITLE
Refatoração do StringHelper e inclusão de casos de teste

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /vendor
 /node_modules
+/build
 Homestead.yaml
 Homestead.json
 .env

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Pablo
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/composer.json
+++ b/composer.json
@@ -6,10 +6,6 @@
     {
       "name": "Alexandre Mota Monteiro",
       "email": "motamonteiro@gmail.com"
-    },
-    {
-      "name": "Pablo Bozzi",
-      "email": "pablobozzi@gmail.com"
     }
   ],
   "require": {},

--- a/composer.json
+++ b/composer.json
@@ -6,9 +6,16 @@
     {
       "name": "Alexandre Mota Monteiro",
       "email": "motamonteiro@gmail.com"
+    },
+    {
+      "name": "Pablo Bozzi",
+      "email": "pablobozzi@gmail.com"
     }
   ],
   "require": {},
+  "require-dev": {
+    "phpunit/phpunit": "^5.7"
+  },
   "autoload": {
     "psr-4": {
       "MotaMonteiro\\Helpers\\":"src/"

--- a/examples/utilHelperExample.php
+++ b/examples/utilHelperExample.php
@@ -1,7 +1,9 @@
 <?php
 
+use MotaMonteiro\Helpers\UtilHelper;
+
 require_once __DIR__ . '/../vendor/autoload.php';
 
-$util = new \MotaMonteiro\Helpers\UtilHelper();
+$util = new UtilHelper();
 
 echo ($util->validarCpf('32878192834')) ? 'valido' : 'invalido';

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit verbose="true"
+         backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="false">
+    <php>
+        <ini name="error_reporting" value="E_ALL" />
+    </php>
+
+    <testsuites>
+        <testsuite name="PHP Coveralls component test suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./src</directory>
+            <exclude>
+                <directory>./examples</directory>
+                <directory>./tests</directory>
+                <directory>./vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+
+    <logging>
+        <log type="coverage-clover" target="build/tests/logs/clover.xml"/>
+    </logging>
+</phpunit>

--- a/readme.md
+++ b/readme.md
@@ -1,30 +1,108 @@
+# helpers
+
 O pacote helpers disponibiliza funcionalidades comuns que podem ser usadas em qualquer projeto PHP.
 
 Existem 2 maneiras de se usar esse pacote:
+
+## Instalação 1 - `traits`
+
+```sh
+$ composer require MotaMonteiro/helpers
+
+```
+
+```php
+use MotaMonteiro\Helpers\Traits\StringHelper;
  
-
-Utilizar através de `traits`:
-
-``` bash
-colocar exemplos de como configurar um projeto usando traits
+class MyClass
+{
+    use StringHelper;
+    
+    public function myFunction()
+    {
+        $cpf = '43354377224';
+        if ($this->validarCpf($cpf))
+        {
+            ...
+        }
+    }
+}
 ```
 
-Ou utilizar através de `functions`:
+## Instalação 2 - `functions`
 
-``` bash
-colocar exemplos de como configurar um projeto usando funções
+```sh
+$ composer require MotaMonteiro/helpers
+
 ```
 
-Utilização no Laravel:
-
-Segue abaixo o passo a passo de como configurar esse pacote utilizando `traits` no Laravel
-
-``` bash
-colocar exemplos de como configurar um projeto usando traits no laravel
+```php
+use MotaMonteiro\Helpers\UtilHelper;
+ 
+class MyClass
+{
+    public function myFunction()
+    {
+        $util = new UtilHelper();
+        
+        $cpf = '43354377224';
+        if ($util->validarCpf($cpf))
+        {
+            ...
+        }
+    }
+}
 ```
 
-Segue abaixo o passo a passo de como configurar esse pacote utilizando `functions` no Laravel
+## Teste
 
-``` bash
-colocar exemplos de como configurar um projeto usando functions no laravel
+Para efetuar os testes basta executar o comando abaixo no terminal:
+
+```sh
+$ ./vendor/bin/phpunit
 ```
+
+Exemplo de saída:
+
+```
+PHPUnit 5.7.21 by Sebastian Bergmann and contributors.
+ 
+Runtime:       PHP 7.0.15 with Xdebug 2.5.0
+Configuration: /Users/pablo/Documents/repositorios/github/fork/helpers/phpunit.xml
+ 
+..........                                                        10 / 10 (100%)
+ 
+Time: 401 ms, Memory: 6.00MB
+ 
+OK (10 tests, 10 assertions)
+ 
+Generating code coverage report in Clover XML format ... done
+```
+
+## Package
+
+https://packagist.org/packages/MotaMonteiro/helpers
+
+## Licença
+
+MIT License
+
+Copyright (c) 2017 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/Traits/DataHelper.php
+++ b/src/Traits/DataHelper.php
@@ -204,7 +204,7 @@ trait DataHelper
 
         $data = (!$data instanceof \DateTime) ? \DateTime::createFromFormat($this->FORMATO_DATA_HORA_BR, $data) : $data;
 
-        if (!$data || $data->format($this->FORMATO_DATA_HORA_BR)) {
+        if (!$data || !$data->format($this->FORMATO_DATA_HORA_BR)) {
             return '01/01/1900 00:00:00';
         }
 

--- a/src/Traits/StringHelper.php
+++ b/src/Traits/StringHelper.php
@@ -36,38 +36,26 @@ trait StringHelper
      */
     public function validarCpf($cpf)
     {
-        //Retira possível mascara
         $cpf = $this->filtrarSomenteNumeros($cpf);
 
-        //Valida tamanho
-        if (strlen($cpf) != 11) {
+        // Remove os CPFs 00000000000, 11111111111, ..., 99999999999
+        if ((strlen($cpf) != 11) || (preg_match('/(\d)\1{10}/', $cpf))) {
             return false;
         }
-
-        //Valida números iguais
-        for ($i = 0; $i < 10; $i++) {
-            if ($cpf == str_repeat($i, 11)) {
+        
+        // Calcula os DVs para verificar se o CPF é verdadeiro
+        for ($i = 9; $i < 11; $i++) {
+            $j = 0;
+            for ($k = 0; $k < $i; $k++) {
+                $j += $cpf{$k} * (($i + 1) - $k);
+            }
+            $j = ((10 * $j) % 11) % 10;
+            if ($cpf{$k} != $j) {
                 return false;
             }
         }
 
-        //Primeiro dígito verificador
-        for ($i = 0, $j = 10, $soma = 0; $i < 9; $i++, $j--) {
-            $soma += $cpf{$i} * $j;
-        }
-
-        $resto = $soma % 11;
-        if ($cpf{9} != ($resto < 2 ? 0 : 11 - $resto)) {
-            return false;
-        }
-
-        //Segundo dígito verificador
-        for ($i = 0, $j = 11, $soma = 0; $i < 10; $i++, $j--) {
-            $soma += $cpf{$i} * $j;
-        }
-
-        $resto = $soma % 11;
-        return $cpf{10} == ($resto < 2 ? 0 : 11 - $resto);
+        return true;
     }
 
     /**
@@ -78,23 +66,17 @@ trait StringHelper
      */
     public function validarCnpj($cnpj)
     {
-        //Retira possível mascara
         $cnpj = $this->filtrarSomenteNumeros($cnpj);
 
-        //Valida tamanho
-        if (strlen($cnpj) != 11) {
+        // Remove os CNPJs 00000000000000, 11111111111111, ..., 99999999999999
+        if ((strlen($cnpj) != 14) || (preg_match('/(\d)\1{13}/', $cnpj))) {
             return false;
         }
 
-        //Valida números iguais
-        for ($i = 0; $i <= 10; $i++) {
-            if ($cnpj == str_repeat($i, 14)) {
-                return false;
-            }
-        }
-
         //Primeiro dígito verificador
-        for ($i = 0, $j = 5, $soma = 0; $i < 12; $i++) {
+        $soma = 0;
+        $j = 5;
+        for ($i = 0; $i < 12; $i++) {
             $soma += $cnpj{$i} * $j;
             $j = ($j == 2) ? 9 : $j - 1;
         }
@@ -105,12 +87,15 @@ trait StringHelper
         }
 
         //Segundo dígito verificador
-        for ($i = 0, $j = 6, $soma = 0; $i < 13; $i++) {
+        $soma = 0;
+        $j = 6;
+        for ($i = 0; $i < 13; $i++) {
             $soma += $cnpj{$i} * $j;
             $j = ($j == 2) ? 9 : $j - 1;
         }
 
         $resto = $soma % 11;
+
         return $cnpj{13} == ($resto < 2 ? 0 : 11 - $resto);
     }
 
@@ -171,13 +156,16 @@ trait StringHelper
 
         //Retira separador de milhar com a virgula
         $numero = str_replace(",", "", $numero);
+        if (!is_numeric($numero)) {
+            return false;
+        }
 
         //Se não tiver ponto
         if (strpos($numero, '.') === false) {
-            return (is_numeric($numero)) ? number_format($numero, 0, ",", ".") : false;
+            return number_format($numero, 0, ",", ".");
         }
 
-        return (is_numeric($numero)) ? number_format($numero, 2, ",", ".") : false;
+        return number_format($numero, 2, ",", ".");
     }
 
     /**
@@ -194,7 +182,11 @@ trait StringHelper
         //Retira separador de milhar com a virgula
         $numero = str_replace(",", "", $numero);
 
-        return (is_numeric($numero)) ? number_format($numero, 2, ",", ".") : false;
+        if(!is_numeric($numero)){
+            return false;
+        }
+
+        return number_format($numero, 2, ",", ".");
     }
 
     /**
@@ -214,7 +206,10 @@ trait StringHelper
         //transforma para numero
         $numero = str_replace(",", ".", $numero);
 
-        return (is_numeric($numero)) ? number_format($numero, 2, ",", ".") : false;
+        if(!is_numeric($numero)){
+            return false;
+        }
+        return number_format($numero, 2, ",", ".");
     }
 
     /**

--- a/tests/TraitStringHelperValidaCnpjTest.php
+++ b/tests/TraitStringHelperValidaCnpjTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use MotaMonteiro\Helpers\Traits\StringHelper;
+use PHPUnit\Framework\TestCase;
+
+class TraitStringHelperValidaCnpjTest extends TestCase
+{
+    use StringHelper;
+
+    public function testValidaCnpjSucesso()
+    {
+        $cnpj = '74456225000193';
+
+        $this->assertTrue($this->validarCnpj($cnpj));
+    }
+
+    public function testValidaCnpjComMascara()
+    {
+        $cnpj = '74.456.225/0001-93';
+
+        $this->assertTrue($this->validarCnpj($cnpj));
+    }
+
+    public function testValidaCnpjQtdeDigitosInvalida()
+    {
+        $cnpj = '0000000000000';
+
+        $this->assertFalse($this->validarCnpj($cnpj));
+    }
+
+    public function testValidaCnpjDigitosIguais()
+    {
+        $cnpj = '00000000000000';
+
+        $this->assertFalse($this->validarCnpj($cnpj));
+    }
+
+    public function testValidaCnpjCaracteresInvalidos()
+    {
+        $cnpj = 'a';
+
+        $this->assertFalse($this->validarCnpj($cnpj));
+    }
+}

--- a/tests/TraitStringHelperValidaCpfTest.php
+++ b/tests/TraitStringHelperValidaCpfTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use MotaMonteiro\Helpers\Traits\StringHelper;
+use PHPUnit\Framework\TestCase;
+
+class TraitStringHelperValidaCpfTest extends TestCase
+{
+    use StringHelper;
+
+    public function testValidaCpfSucesso()
+    {
+        $cpf = '43354377224';
+
+        $this->assertTrue($this->validarCpf($cpf));
+    }
+
+    public function testValidaCpfComMascara()
+    {
+        $cpf = '433.543.772-24';
+
+        $this->assertTrue($this->validarCpf($cpf));
+    }
+
+    public function testValidaCpfQtdeDigitosInvalida()
+    {
+        $cpf = '0000000000';
+
+        $this->assertFalse($this->validarCpf($cpf));
+    }
+
+    public function testValidaCpfDigitosIguais()
+    {
+        $cpf = '00000000000';
+
+        $this->assertFalse($this->validarCpf($cpf));
+    }
+
+    public function testValidaCpfCaracteresInvalidos()
+    {
+        $cpf = 'a';
+
+        $this->assertFalse($this->validarCpf($cpf));
+    }
+}


### PR DESCRIPTION
Alterações nesse PR:
- Refatoração nos métodos validaCpf e validaCnpj
- Adicionada dependência do PHPUnit
- Criações dos casos de teste das funções validaCpf e validaCnpj
- Incluído arquivo da licença LICENSE (MIT)
- Alterado arquivo README.md